### PR TITLE
Fix perl6 build

### DIFF
--- a/lib/travis/build/script/perl6.rb
+++ b/lib/travis/build/script/perl6.rb
@@ -26,7 +26,7 @@ module Travis
           sh.echo 'and cc @paultcochrane, @hoelzro, @ugexe, and @tony-o', ansi: :red
 
           sh.echo 'Installing Rakudo (MoarVM)', ansi: :yellow
-          sh.cmd 'git clone https://github.com/tadzik/rakudobrew.git ${TRAVIS_HOME}/.rakudobrew'
+          sh.cmd 'git clone -b v1 https://github.com/tadzik/rakudobrew.git ${TRAVIS_HOME}/.rakudobrew'
           sh.export 'PATH', '${TRAVIS_HOME}/.rakudobrew/bin:$PATH', echo: false
         end
 


### PR DESCRIPTION
`rakudobrew` just had a major upgrade which breaks the way rakudobrew is used here. This change makes sure the old, still working, version of rakudobrew is used.